### PR TITLE
增加buffer实现 (未完成)

### DIFF
--- a/util/buf.go
+++ b/util/buf.go
@@ -1,0 +1,243 @@
+package util
+
+import "io"
+
+const (
+	defaultBufSize = 2048
+)
+
+type OutOfBufError string
+
+func (e OutOfBufError) Error() string {
+	return "websocket.buf:\n OutOfBufError: " + string(e)
+}
+
+type ReaderError string
+
+func (e ReaderError) Error() string {
+	return "websocket.buf:\n ReaderError: " + string(e)
+}
+
+type BaseBuf interface {
+	Size() int
+
+	Array() []byte
+
+	Copy() BaseBuf
+
+	WriteIndex(idx int) error
+
+	ReadIndex(idx int) error
+
+	GetWriteIndex() int
+
+	GetReadIndex() int
+
+	WriteableBytes() int
+
+	ReadableBytes() int
+
+	DiscardReadBytes()
+
+	GetByte(i int) (b byte, err error)
+
+	GetBytes(i int, dst []byte) error
+
+	SetByte(i int, b byte) error
+
+	SetBytes(i int, src []byte) error
+
+	WriteTo(w io.Writer) error
+
+	WriteToWithLen(len int, w io.Writer) error
+
+	ReadFrom(r io.Reader) (n int, err error)
+
+	ReadFromWithLen(len int, r io.Reader) (n int, err error)
+}
+
+type ByteBuf struct {
+	//reader index
+	rIdx int
+	//writer index
+	wIdx int
+
+	//buf
+	array []byte
+}
+
+func NewBufWithSize(size int) BaseBuf {
+	return &ByteBuf{
+		rIdx:  0,
+		wIdx:  0,
+		array: make([]byte, size),
+	}
+}
+
+func NewBufWithArray(b []byte) BaseBuf {
+	return &ByteBuf{
+		rIdx:  0,
+		wIdx:  0,
+		array: b,
+	}
+}
+
+func NewBuf() BaseBuf {
+	return NewBufWithSize(defaultBufSize)
+}
+
+func checkIndex(idx int, buf BaseBuf) error {
+	if idx < 0 {
+		return OutOfBufError("idx must be a positive")
+	}
+
+	if idx > buf.Size() {
+		return OutOfBufError("idx out of Buffer")
+	}
+
+	return nil
+}
+
+func (b *ByteBuf) ReadIndex(idx int) error {
+	err := checkIndex(idx, b)
+
+	if err != nil {
+		return err
+	}
+
+	if idx > b.wIdx {
+		return OutOfBufError("idx must be less than or equal to writeIndex")
+	}
+
+	b.rIdx = idx
+	return nil
+}
+
+func (b *ByteBuf) WriteIndex(idx int) error {
+	if idx < 0 {
+		return OutOfBufError("idx must be a positive")
+	}
+
+	if idx > b.Size() {
+		return OutOfBufError("idx must be less than or equal to bufsize")
+	}
+
+	b.rIdx = idx
+	return nil
+}
+
+func (b *ByteBuf) GetWriteIndex() int {
+	return b.wIdx
+}
+
+func (b *ByteBuf) GetReadIndex() int {
+	return b.rIdx
+}
+
+func (b *ByteBuf) Size() int {
+	return len(b.array)
+}
+
+func (b *ByteBuf) Array() []byte {
+	return b.array
+}
+
+func (b *ByteBuf) Copy() BaseBuf {
+	cp := make([]byte, b.Size())
+	copy(cp, b.array)
+	return NewBufWithArray(cp)
+}
+
+func (b *ByteBuf) WriteableBytes() int {
+	return b.Size() - b.wIdx
+}
+
+func (b *ByteBuf) ReadableBytes() int {
+	return b.wIdx - b.rIdx
+}
+
+func (buf *ByteBuf) GetByte(i int) (b byte, err error) {
+	err = checkIndex(i, buf)
+	if err != nil {
+		return 0, err
+	}
+
+	b = buf.array[i]
+	return
+}
+
+func (b *ByteBuf) GetBytes(i int, dst []byte) error {
+	err := checkIndex(i, b)
+	if err != nil {
+		return err
+	}
+
+	copy(dst, b.array[i:])
+	return nil
+}
+
+func (buf *ByteBuf) SetByte(i int, b byte) error {
+	err := checkIndex(i, buf)
+	if err != nil {
+		return err
+	}
+
+	buf.array[i] = b
+	return nil
+}
+
+func (b *ByteBuf) SetBytes(i int, src []byte) error {
+	err := checkIndex(i, b)
+	if err != nil {
+		return err
+	}
+
+	copy(b.array[i:], src)
+	return nil
+}
+
+func (b *ByteBuf) DiscardReadBytes() {
+	if b.rIdx == 0 {
+		return
+	}
+
+	copy(b.array, b.array[b.rIdx:b.wIdx])
+}
+
+func (b *ByteBuf) WriteTo(w io.Writer) error {
+	return b.WriteToWithLen(b.ReadableBytes(), w)
+}
+
+func (b *ByteBuf) WriteToWithLen(len int, w io.Writer) error {
+	if b.ReadableBytes() < len {
+		return OutOfBufError("len for writing data is out of Buffer")
+	}
+
+	wb, err := w.Write(b.array[b.rIdx : b.rIdx + len])
+	if wb < len && err == nil {
+		err = io.ErrShortWrite
+	}
+
+	b.rIdx += wb
+	return err
+}
+
+func (b *ByteBuf) ReadFrom(r io.Reader) (n int, err error) {
+	return b.ReadFromWithLen(b.WriteableBytes(), r)
+}
+
+func (b *ByteBuf) ReadFromWithLen(len int, r io.Reader) (n int, err error) {
+	if b.WriteableBytes() < len {
+		return 0, OutOfBufError("len for reading data is out of Buffer")
+	}
+
+	rb, err := r.Read(b.array[b.wIdx : b.wIdx+len])
+
+	if rb < 0 {
+		panic(ReaderError("reader returned nagative count from Read"))
+	}
+
+	b.wIdx += rb
+
+	return rb, err
+}

--- a/util/bufUtil.go
+++ b/util/bufUtil.go
@@ -1,0 +1,330 @@
+package util
+
+import "io"
+
+type sliceBuf struct {
+	src BaseBuf
+
+	rIdx int
+	wIdx int
+
+	offset int
+	dLen   int
+}
+
+func slice(src BaseBuf, from, to int) BaseBuf {
+	return &sliceBuf{
+		src: src,
+		rIdx: 0,
+		wIdx: 0,
+		offset: from,
+		dLen: to - from,
+	}
+}
+
+func (buf *sliceBuf) Size() int {
+	return buf.dLen
+}
+
+func (buf *sliceBuf) Array() []byte {
+	return buf.src.Array()[buf.offset : buf.offset+buf.dLen]
+}
+
+func (buf *sliceBuf) Copy() BaseBuf {
+	cp := make([]byte, buf.Size())
+	copy(cp, buf.Array())
+	return NewBufWithArray(cp)
+}
+
+func (buf *sliceBuf) WriteIndex(idx int) error {
+	err := checkIndex(idx, buf)
+	if err != nil {
+		return err
+	}
+
+	buf.rIdx = idx
+	return nil
+}
+
+func (buf *sliceBuf) ReadIndex(idx int) error {
+	err := checkIndex(idx, buf)
+	if err != nil {
+		return err
+	}
+
+	buf.wIdx = idx
+	return nil
+}
+
+func (buf *sliceBuf) GetWriteIndex() int {
+	return buf.wIdx
+}
+
+func (buf *sliceBuf) GetReadIndex() int {
+	return buf.rIdx
+}
+
+func (buf *sliceBuf) WriteableBytes() int {
+	return buf.Size() - buf.wIdx
+}
+
+func (buf *sliceBuf) ReadableBytes() int {
+	return buf.wIdx - buf.rIdx
+}
+
+func (buf *sliceBuf) DiscardReadBytes() {
+	if buf.rIdx == 0 {
+		return
+	}
+
+	copy(buf.Array(), buf.Array()[buf.rIdx:buf.wIdx])
+}
+
+func (buf *sliceBuf) GetByte(i int) (b byte, err error) {
+	err = checkIndex(i, buf)
+	if err != nil {
+		return 0, err
+	}
+
+	b = buf.Array()[i+buf.offset]
+	return
+}
+
+func (buf *sliceBuf) GetBytes(i int, dst []byte) error {
+	err := checkIndex(i, buf)
+	if err != nil {
+		return err
+	}
+
+	copy(dst, buf.Array()[i:])
+	return nil
+}
+
+func (buf *sliceBuf) SetByte(i int, b byte) error {
+	err := checkIndex(i, buf)
+	if err != nil {
+		return err
+	}
+
+	buf.Array()[i] = b
+	return nil
+}
+
+func (buf *sliceBuf) SetBytes(i int, src []byte) error {
+	err := checkIndex(i, buf)
+	if err != nil {
+		return err
+	}
+
+	copy(buf.Array()[i:], src)
+	return err
+}
+
+func (buf *sliceBuf) WriteTo(w io.Writer) error {
+	return buf.WriteToWithLen(buf.WriteableBytes(), w)
+}
+
+func (buf *sliceBuf) WriteToWithLen(len int, w io.Writer) error {
+	if buf.ReadableBytes() < len {
+		return OutOfBufError("len for writing data is out of Buffer")
+	}
+
+	wb, err := w.Write(buf.Array()[buf.rIdx:buf.rIdx + len])
+	if wb < len && err == nil {
+		err = io.ErrShortWrite
+	}
+
+	buf.rIdx += wb
+	return err
+}
+
+func (buf *sliceBuf) ReadFrom(r io.Reader) (n int, err error) {
+	return buf.ReadFromWithLen(buf.WriteableBytes(), r)
+}
+
+func (buf *sliceBuf) ReadFromWithLen(len int, r io.Reader) (n int, err error) {
+	if buf.WriteableBytes() < len {
+		return 0, OutOfBufError("len for reading data is out of Buffer")
+	}
+
+	rb, err := r.Read(buf.Array()[buf.wIdx : buf.wIdx+len])
+
+	if rb < 0 {
+		panic(ReaderError("reader returned nagative count from Read"))
+	}
+
+	buf.wIdx += rb
+
+	return rb, err
+}
+
+type duplicateBuf struct {
+	src BaseBuf
+
+	rIdx int
+	wIdx int
+}
+
+func duplicate(src BaseBuf) BaseBuf {
+
+}
+
+func (buf *duplicateBuf)Size() int {
+
+}
+
+func (buf *duplicateBuf)Array() []byte {
+
+}
+
+func (buf *duplicateBuf)Copy() BaseBuf {
+
+}
+
+func (buf *duplicateBuf)WriteIndex(idx int) error {
+
+}
+
+func (buf *duplicateBuf)ReadIndex(idx int) error {
+
+}
+
+func (buf *duplicateBuf)GetWriteIndex() int {
+
+}
+
+func (buf *duplicateBuf)GetReadIndex() int {
+
+}
+
+func (buf *duplicateBuf)WriteableBytes() int {
+
+}
+
+func (buf *duplicateBuf)ReadableBytes() int {
+
+}
+
+func (buf *duplicateBuf)DiscardReadBytes() {
+
+}
+
+func (buf *duplicateBuf)GetByte(i int) (b byte, err error) {
+
+}
+
+func (buf *duplicateBuf)GetBytes(i int, dst []byte) error {
+
+}
+
+func (buf *duplicateBuf)SetByte(i int, b byte) error {
+
+}
+
+func (buf *duplicateBuf)SetBytes(i int, src []byte) error {
+
+}
+
+func (buf *duplicateBuf)WriteTo(w io.Writer) error {
+
+}
+
+func (buf *duplicateBuf)WriteToWithLen(len int, w io.Writer) error {
+
+}
+
+func (buf *duplicateBuf)ReadFrom(r io.Reader) (n int, err error) {
+
+}
+
+func (buf *duplicateBuf)ReadFromWithLen(len int, r io.Reader) (n int, err error) {
+
+}
+
+type bufComponent struct {
+	src BaseBuf
+
+	sIdx int
+	eIdx int
+}
+
+type CompositeBuf struct {
+	child []bufComponent
+
+	rIdx int
+	wIdx int
+
+	lastComp bufComponent
+}
+
+func (buf *CompositeBuf)Size() int {
+	
+}
+
+func (buf *CompositeBuf)Array() []byte {
+	
+}
+
+func (buf *CompositeBuf)Copy() BaseBuf {
+	
+}
+
+func (buf *CompositeBuf)WriteIndex(idx int) error {
+	
+}
+
+func (buf *CompositeBuf)ReadIndex(idx int) error {
+	
+}
+
+func (buf *CompositeBuf)GetWriteIndex() int {
+	
+}
+
+func (buf *CompositeBuf)GetReadIndex() int {
+	
+}
+
+func (buf *CompositeBuf)WriteableBytes() int {
+	
+}
+
+func (buf *CompositeBuf)ReadableBytes() int {
+	
+}
+
+func (buf *CompositeBuf)DiscardReadBytes() {
+	
+}
+
+func (buf *CompositeBuf)GetByte(i int) (b byte, err error) {
+	
+}
+
+func (buf *CompositeBuf)GetBytes(i int, dst []byte) error {
+	
+}
+
+func (buf *CompositeBuf)SetByte(i int, b byte) error {
+	
+}
+
+func (buf *CompositeBuf)SetBytes(i int, src []byte) error {
+	
+}
+
+func (buf *CompositeBuf)WriteTo(w io.Writer) error {
+	
+}
+
+func (buf *CompositeBuf)WriteToWithLen(len int, w io.Writer) error {
+	
+}
+
+func (buf *CompositeBuf)ReadFrom(r io.Reader) (n int, err error) {
+	
+}
+
+func (buf *CompositeBuf)ReadFromWithLen(len int, r io.Reader) (n int, err error) {
+	
+}


### PR DESCRIPTION
添加buf.go:
  - BaseBuf  泛指支持读写操作的缓冲区接口
  - ByteBuf  一个缓冲区接口的标准实现
添加bufUtil.go拓展BaseBuf的功能：
  - slice (已实现)
  - duplicate (未实现)
  - composite (未实现)
  - warpped (构想中)